### PR TITLE
jackson update via bom

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -15,7 +15,7 @@ jobs:
             sudo make install   
       - uses: actions/checkout@v2
       # Step that does that actual cache save and restore
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '17.0.4+8'
+          java-version: '21.0.2+13.0.LTS'
           distribution: 'adopt'
       - name: Build with mvn
         run: mvn -B -ntp  clean install 

--- a/generated/src/main/resources/pom.xml
+++ b/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-quay-client</artifactId>
-  <version>2.0.2</version>
+  <version>2.0.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
@@ -36,13 +36,13 @@
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>3.0.9</version>
+      <version>3.0.17</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>3.0.9</version>
+      <version>3.0.17</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -66,19 +66,19 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>3.0.9</version>
+      <version>3.0.17</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.14.2</version>
+      <version>2.18.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.14.2</version>
+      <version>2.18.2</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.14.2</version>
+      <version>2.18.2</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
@@ -102,19 +102,19 @@
     <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
-      <version>3.0.0</version>
+      <version>3.1.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-common</artifactId>
-      <version>3.0.9</version>
+      <version>3.0.17</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.14.2</version>
+      <version>2.18.2</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <github.url>scm:git:git@github.com:dockstore/swagger-java-quay-client.git</github.url>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dockstore-core.version>1.15.0-prealpha.1</dockstore-core.version>
+        <dockstore-core.version>1.17.0</dockstore-core.version>
         <maven-failsafe.version>2.21.0</maven-failsafe.version>
         <maven-surefire.version>2.21.0</maven-surefire.version>
         <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
@@ -247,7 +247,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.5.3.0</version>
+                    <version>4.9.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
use bom to clear out jackson warnings for swagger clients.
Build updates mostly to match webservice repo or to avoid deprecation

https://ucsc-cgl.atlassian.net/browse/SEAB-7210